### PR TITLE
Fixed missing host setting

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -8,6 +8,7 @@ module.exports = function(RED) {
     var refreshToken = null;
     var accessToken = null;
     var region = null;
+    var IotEndpoint = null;
     var identityPool = null;
     var userPool = null;
     var retries = 0;
@@ -24,6 +25,7 @@ module.exports = function(RED) {
     }
     function setupAWSCredentials(){
       AWS.config.region = region;
+      AWS.config.host = IotEndpoint;
       AWS.config.credentials = new AWS.CognitoIdentityCredentials({ IdentityPoolId: identityPool});
     }
     function loginToAWS(token, cb){
@@ -108,7 +110,7 @@ module.exports = function(RED) {
         identityPool = manifest.IdentityPool;
         region = manifest.Region;
         userPool = manifest.UserPool;
-
+	IotEndpoint = manifest.IotEndpointATS;
         setupAWSCredentials();
         authenticateUser(node.invoke.bind(null), config, function(err, res){
           if(err) node.emit("error", err);

--- a/lib/event-in.js
+++ b/lib/event-in.js
@@ -15,9 +15,8 @@ module.exports = function(RED) {
     this.account.on("login", function() {
       var creds = AWS.config.credentials;
 
-      console.log({ creds });
-
       var mqtt = (node.mqtt = AWSIot.device({
+	host: AWS.config.host,
         region: AWS.config.region,
         protocol: "wss",
         maximumReconnectTimeMs: 8000,

--- a/lib/event-out.js
+++ b/lib/event-out.js
@@ -13,8 +13,8 @@ module.exports = function(RED) {
 
     this.account.on("login", function() {
       var creds = AWS.config.credentials;
-
-      node.mqtt = AWSIot.device({
+        node.mqtt = AWSIot.device({
+	host: AWS.config.host,
         region: AWS.config.region,
         protocol: "wss",
         maximumReconnectTimeMs: 8000,

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-managed-iot-cloud",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "API end event in/out nodes for Telenor Managed IoT Cloud",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Gustav Jorlöv <gustav.jorlov@telenorconnexion.com>",
+  "author": "Gustav Jorlöv <mic-dev@telenorconnexion.com>",
   "license": "ISC",
   "dependencies": {
     "aws-iot-device-sdk": "^1.0.12",


### PR DESCRIPTION
* Added the setting of host for the connection to the MQTT broker instead of fall back to default "data.iot" generic endpoint.
* Upped version to 1.0.2